### PR TITLE
2 ソースコードの安全性の向上

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/MainActivity.kt
@@ -4,12 +4,5 @@
 package jp.co.yumemi.android.codecheck
 
 import androidx.appcompat.app.AppCompatActivity
-import java.util.Date
 
-class MainActivity : AppCompatActivity(R.layout.activity_main) {
-
-    companion object {
-        /** 前回検索日付 */
-        lateinit var lastSearchDate: Date
-    }
-}
+class MainActivity : AppCompatActivity(R.layout.activity_main)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
@@ -35,10 +35,17 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
 
         binding.ownerIconView.load(repositoryItem.ownerIconUrl)
         binding.nameView.text = repositoryItem.name
-        binding.languageView.text = repositoryItem.language
-        binding.starsView.text = "${repositoryItem.stargazersCount} stars"
-        binding.watchersView.text = "${repositoryItem.watchersCount} watchers"
-        binding.forksView.text = "${repositoryItem.forksCount} forks"
-        binding.openIssuesView.text = "${repositoryItem.openIssuesCount} open issues"
+        binding.languageView.text = getString(R.string.written_language, repositoryItem.language)
+        binding.starsView.text = getString(R.string.stars, repositoryItem.stargazersCount)
+        binding.watchersView.text = getString(R.string.watchers, repositoryItem.watchersCount)
+        binding.forksView.text = getString(R.string.forks, repositoryItem.forksCount)
+        binding.openIssuesView.text =
+            getString(R.string.open_issues, repositoryItem.openIssuesCount)
+    }
+
+    /** ビュー破棄時の処理 */
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
@@ -9,7 +9,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
-import jp.co.yumemi.android.codecheck.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.codecheck.databinding.FragmentRepositoryDetailBinding
 
 /** リポジトリ詳細画面 */
@@ -25,7 +24,7 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        Log.d("検索した日時", lastSearchDate.toString())
+        Log.d("検索した日時", args.lastSearchDate)
         val binding = FragmentRepositoryDetailBinding.bind(view)
         val repositoryItem = args.repositoryItem
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
@@ -16,8 +16,6 @@ import jp.co.yumemi.android.codecheck.databinding.FragmentRepositoryDetailBindin
 class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
 
     private val args: RepositoryDetailFragmentArgs by navArgs()
-    private var _binding: FragmentRepositoryDetailBinding? = null
-    private val binding get() = _binding!!
 
     /**
      * ビュー生成時の処理
@@ -28,9 +26,7 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
         super.onViewCreated(view, savedInstanceState)
 
         Log.d("検索した日時", lastSearchDate.toString())
-
-        _binding = FragmentRepositoryDetailBinding.bind(view)
-
+        val binding = FragmentRepositoryDetailBinding.bind(view)
         val repositoryItem = args.repositoryItem
 
         binding.ownerIconView.load(repositoryItem.ownerIconUrl)
@@ -41,11 +37,5 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
         binding.forksView.text = getString(R.string.forks, repositoryItem.forksCount)
         binding.openIssuesView.text =
             getString(R.string.open_issues, repositoryItem.openIssuesCount)
-    }
-
-    /** ビュー破棄時の処理 */
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryItem.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryItem.kt
@@ -1,0 +1,25 @@
+package jp.co.yumemi.android.codecheck
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * リポジトリーアイテム
+ * @param name リポジトリー名
+ * @param ownerIconUrl オーナーアイコンURL
+ * @param language 言語
+ * @param stargazersCount スターガザー数
+ * @param watchersCount ウォッチャー数
+ * @param forksCount フォーク数
+ * @param openIssuesCount オープンイシュー数
+ */
+@Parcelize
+data class RepositoryItem(
+    val name: String,
+    val ownerIconUrl: String,
+    val language: String,
+    val stargazersCount: Long,
+    val watchersCount: Long,
+    val forksCount: Long,
+    val openIssuesCount: Long,
+) : Parcelable

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryFragment.kt
@@ -31,11 +31,11 @@ class SearchRepositoryFragment : Fragment(R.layout.fragment_search_repository) {
 
         val binding = FragmentSearchRepositoryBinding.bind(view)
 
-        val viewModel = SearchRepositoryViewModel(context!!)
+        val viewModel = SearchRepositoryViewModel()
 
-        val layoutManager = LinearLayoutManager(context!!)
+        val layoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration =
-            DividerItemDecoration(context!!, layoutManager.orientation)
+            DividerItemDecoration(requireContext(), layoutManager.orientation)
         val adapter = CustomAdapter(object : CustomAdapter.OnItemClickListener {
             override fun itemClick(repositoryItem: RepositoryItem) {
                 navigateToRepositoryFragment(repositoryItem)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -17,9 +18,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import jp.co.yumemi.android.codecheck.databinding.FragmentSearchRepositoryBinding
+import java.util.Date
 
 /** リポジトリー検索画面 */
 class SearchRepositoryFragment : Fragment(R.layout.fragment_search_repository) {
+    private val viewModel: SearchRepositoryViewModel by viewModels()
 
     /**
      * ビュー生成時の処理
@@ -31,7 +34,6 @@ class SearchRepositoryFragment : Fragment(R.layout.fragment_search_repository) {
 
         val binding = FragmentSearchRepositoryBinding.bind(view)
 
-        val viewModel = SearchRepositoryViewModel()
 
         val layoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration =
@@ -67,8 +69,9 @@ class SearchRepositoryFragment : Fragment(R.layout.fragment_search_repository) {
      * @param repositoryItem リポジトリーアイテム
      */
     fun navigateToRepositoryFragment(repositoryItem: RepositoryItem) {
+        val date = viewModel.lastSearchDate.value ?: Date()
         val action = SearchRepositoryFragmentDirections
-            .actionRepositoriesFragmentToRepositoryFragment(repositoryItem = repositoryItem)
+            .actionRepositoriesFragmentToRepositoryFragment(repositoryItem, date.toString())
         findNavController().navigate(action)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryViewModel.kt
@@ -30,7 +30,7 @@ class SearchRepositoryViewModel : ViewModel() {
         val client = HttpClient(Android)
 
         return@runBlocking GlobalScope.async {
-            val response: HttpResponse = client?.get("https://api.github.com/search/repositories") {
+            val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
                 header("Accept", "application/vnd.github.v3+json")
                 parameter("q", inputText)
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchRepositoryViewModel.kt
@@ -3,8 +3,6 @@
  */
 package jp.co.yumemi.android.codecheck
 
-import android.content.Context
-import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.call.receive
@@ -17,17 +15,11 @@ import jp.co.yumemi.android.codecheck.MainActivity.Companion.lastSearchDate
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Date
 
-/**
- * リポジトリーの検索結果を返すためのViewModel
- * @param context コンテキスト
- */
-class SearchRepositoryViewModel(
-    val context: Context
-) : ViewModel() {
+/** リポジトリーの検索結果を返すためのViewModel */
+class SearchRepositoryViewModel : ViewModel() {
 
     /**
      * リポジトリーの検索結果を返す
@@ -64,7 +56,7 @@ class SearchRepositoryViewModel(
                     RepositoryItem(
                         name = name,
                         ownerIconUrl = ownerIconUrl,
-                        language = context.getString(R.string.written_language, language),
+                        language = language,
                         stargazersCount = stargazersCount,
                         watchersCount = watchersCount,
                         forksCount = forksCount,
@@ -79,24 +71,3 @@ class SearchRepositoryViewModel(
         }.await()
     }
 }
-
-/**
- * リポジトリーアイテム
- * @param name リポジトリー名
- * @param ownerIconUrl オーナーアイコンURL
- * @param language 言語
- * @param stargazersCount スターガザー数
- * @param watchersCount ウォッチャー数
- * @param forksCount フォーク数
- * @param openIssuesCount オープンイシュー数
- */
-@Parcelize
-data class RepositoryItem(
-    val name: String,
-    val ownerIconUrl: String,
-    val language: String,
-    val stargazersCount: Long,
-    val watchersCount: Long,
-    val forksCount: Long,
-    val openIssuesCount: Long,
-) : Parcelable

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -23,6 +23,8 @@
         <argument
             android:name="repositoryItem"
             app:argType="jp.co.yumemi.android.codecheck.RepositoryItem" />
+		<argument
+			android:name="lastSearchDate"
+			app:argType="string" />
     </fragment>
-
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,9 @@
     <string name="app_name">Android Engineer CodeCheck</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="written_language">Written in %s</string>
+
+	<string name="stars">%1$d stars</string>
+	<string name="watchers">%1$d watchers</string>
+	<string name="forks">%1$d forks</string>
+	<string name="open_issues">%1$d open issues</string>
 </resources>


### PR DESCRIPTION
## Issues
#2 
## コミット内容
1. [非 null 表明演算子をrequireContext()に置き換えた](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/9e4ee99c448f88e08377266b06f602293eaa7a4f)：エラーハンドリングが改善されました。
2. [bindingの解放とリソースから文字列を呼ぶように変更](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/287e77f9add819a1b9fd4db7831ebcfbb7344548)：メモリリークが防止され、ハードコードを削除しました。</br>
3. [contextに依存しないように変更](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/5fc658b650b62aa31837a361bbf7c3efc12c6cf6)：ViewModelがcontextに依存することで、メモリリークする可能性があるため変更しました。</br>
4. [nullでないインスタンスに対するエルビス演算子を削除](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/da1c1d3e7bbf4265807b2f3e8486e549cd2d4f80)：不要なnullチェックを削除し、コードの可読性を向上させました。</br>
5. [RepositoryItemを別ファイルに切り分け](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/20a6bdcefc90b0a6e663c3076f77b40bd059d9d0)：ひとまとめになり、わかりにくかったため変更しました。
6. [bindingのスコープを最小限に変更](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/f89cb23de885d6ff861b47c41d46685355e112c2)：メモリリークの防止と可読性の向上のため変更しました。
7. [前回検索日付の変数を削除](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/afbf1c9775318a0663730c5c2810d058d5e1f29f)：MainActivityで宣言されていた前回検索日付の変数を別クラスで管理するために削除
8. [lastSearchDateをviewModel内でインスタンスを持つように変更](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/e1fef618406b1a6a520e03b262a23be43183027b)：状態の管理が一元化され、スコープも最小限にしました。
9. [navArgsで前回検索日付を取得するように変更](https://github.com/0v0d/android-engineer-codecheck/pull/11/commits/ba2144969404d2a83d0a98e2d7089d447ed3a0a7)：前回の検索日付を安全に取得できるようにしました。