### PR TITLE
依存関係の修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
     //Dagger-Hilt
     implementation "com.google.dagger:hilt-android:2.51"
-    implementation 'androidx.test:runner:1.5.2'
     kapt "com.google.dagger:hilt-compiler:2.51"
     // MoshiのConverterを使うためのライブラリ
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
@@ -66,6 +65,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation "com.google.dagger:hilt-android-testing:2.51"
     kaptTest "com.google.dagger:hilt-android-compiler:2.51"
+    testImplementation 'androidx.test:runner:1.5.2'
 }
 kapt {
     correctErrorTypes true


### PR DESCRIPTION
## コミット内容
1.[androidx.test:runner:1.5.2がimplementationスコープになっていたため修正](https://github.com/0v0d/android-engineer-codecheck/pull/22/commits/8dd13c37577e07368ef13eb29353b28cabc350b4) : androidx.test:runner:1.5.2がimplementationスコープになっていたため、testImplementationに変更